### PR TITLE
fix: disable babel transform es2015 modules to commonjs for es6 build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
   plugins: ["transform-export-extensions", "transform-decorators-legacy", "lodash"],
-  presets: ["es2015", "react", "stage-0"]
+  presets: [["es2015", { "modules": false }], "react", "stage-0"],
+  env: {
+    commonjs: {
+      plugins: ["transform-es2015-modules-commonjs"]
+    }
+  }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -2,8 +2,7 @@
   plugins: ["transform-export-extensions", "transform-decorators-legacy", "lodash"],
   presets: [["es2015", { "modules": false }], "react", "stage-0"],
   env: {
-    commonjs: {
-      plugins: ["transform-es2015-modules-commonjs"]
-    }
+    commonjs: { plugins: ["transform-es2015-modules-commonjs"] },
+    test: { plugins: ["transform-es2015-modules-commonjs"] }
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-script: "./node_modules/karma/bin/karma start ./karma.conf.js --browsers Firefox --single-run --no-auto-watch --capture-timeout 60000"
+script: "NODE_ENV=test ./node_modules/karma/bin/karma start ./karma.conf.js --browsers Firefox --single-run --no-auto-watch --capture-timeout 60000"

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "build-es6": "rimraf es6 && babel ./src -d es6",
     "build-umd": "NODE_ENV=development BABEL_ENV=commonjs webpack src/index.js umd/ReactSmooth.js",
     "build-min": "NODE_ENV=production BABEL_ENV=commonjs webpack src/index.js umd/ReactSmooth.min.js",
-    "test": "BABEL_ENV=commonjs ./node_modules/.bin/karma start --single-run",
-    "test-watch": "BABEL_ENV=commonjs ./node_modules/.bin/karma start",
-    "test-browser": "BABEL_ENV=commonjs ./node_modules/.bin/karma start",
+    "test": "NODE_ENV=test ./node_modules/.bin/karma start --single-run",
+    "test-watch": "NODE_ENV=test ./node_modules/.bin/karma start",
+    "test-browser": "NODE_ENV=test ./node_modules/.bin/karma start",
     "demo": "BABEL_ENV=commonjs webpack-dev-server  --progress --port 4000  --colors --content-base demo --hot --inline --config demo/webpack.config.js",
     "lint": "eslint src"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.17",
   "description": "react animation library",
   "main": "lib/index",
+  "module": "es6/index",
   "jsnext:main": "es6/index",
   "files": [
     "*.md",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "npm run build-cjs && npm run build-es6 && rimraf umd && npm run build-umd && npm run build-min",
-    "build-cjs": "BABEL_ENV=commonjs rimraf lib && babel ./src -d lib --plugins=transform-es2015-modules-commonjs",
+    "build-cjs": "BABEL_ENV=commonjs rimraf lib && babel ./src -d lib",
     "build-es6": "rimraf es6 && babel ./src -d es6",
     "build-umd": "NODE_ENV=development BABEL_ENV=commonjs webpack src/index.js umd/ReactSmooth.js",
     "build-min": "NODE_ENV=production BABEL_ENV=commonjs webpack src/index.js umd/ReactSmooth.min.js",

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
   ],
   "scripts": {
     "build": "npm run build-cjs && npm run build-es6 && rimraf umd && npm run build-umd && npm run build-min",
-    "build-cjs": "rimraf lib && babel ./src -d lib",
-    "build-es6": "rimraf es6 && babel ./src -d es6 --blacklist=es6.modules",
-    "build-umd": "NODE_ENV=development webpack src/index.js umd/ReactSmooth.js",
-    "build-min": "NODE_ENV=production webpack src/index.js umd/ReactSmooth.min.js",
-    "test": "./node_modules/.bin/karma start --single-run",
-    "test-watch": "./node_modules/.bin/karma start",
-    "test-browser": "./node_modules/.bin/karma start",
-    "demo": "webpack-dev-server  --progress --port 4000  --colors --content-base demo --hot --inline --config demo/webpack.config.js",
+    "build-cjs": "BABEL_ENV=commonjs rimraf lib && babel ./src -d lib --plugins=transform-es2015-modules-commonjs",
+    "build-es6": "rimraf es6 && babel ./src -d es6",
+    "build-umd": "NODE_ENV=development BABEL_ENV=commonjs webpack src/index.js umd/ReactSmooth.js",
+    "build-min": "NODE_ENV=production BABEL_ENV=commonjs webpack src/index.js umd/ReactSmooth.min.js",
+    "test": "BABEL_ENV=commonjs ./node_modules/.bin/karma start --single-run",
+    "test-watch": "BABEL_ENV=commonjs ./node_modules/.bin/karma start",
+    "test-browser": "BABEL_ENV=commonjs ./node_modules/.bin/karma start",
+    "demo": "BABEL_ENV=commonjs webpack-dev-server  --progress --port 4000  --colors --content-base demo --hot --inline --config demo/webpack.config.js",
     "lint": "eslint src"
   },
   "pre-commit": [


### PR DESCRIPTION
Same as https://github.com/recharts/recharts/pull/440