### PR TITLE
packaging fixes

### DIFF
--- a/src/AnimateGroup.js
+++ b/src/AnimateGroup.js
@@ -1,5 +1,5 @@
 import React, { Component, Children } from 'react';
-import ReactTransitionGroup from 'react-transition-group/TransitionGroup';
+import { TransitionGroup as ReactTransitionGroup } from 'react-transition-group';
 import PropTypes from 'prop-types';
 import AnimateGroupChild from './AnimateGroupChild';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,9 +22,9 @@ var config = {
     }],
     resolve: {
       alias: {
-        'react': path.resolve(__dirname, './node_modules/react'),
-        'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
-        'react-transition-group': path.resolve(__dirname, './node_modules/react-transition-group'),
+        'react': path.join(__dirname, './node_modules/react'),
+        'react-dom': path.join(__dirname, './node_modules/react-dom'),
+        'react-transition-group': path.join(__dirname, './node_modules/react-transition-group'),
       }
     },
   },
@@ -37,7 +37,7 @@ var config = {
       amd: 'react'
     },
     'react-transition-group': {
-      root: ['React','addons','CSSTransitionGroup'],
+      root: ['ReactTransitionGroup'],
       commonjs2: 'react-transition-group',
       commonjs: 'react-transition-group',
       amd: 'react-transition-group'


### PR DESCRIPTION
prevent packaging react-transition-group in the react-smooth UMD module, fix external name
follow-up for #16 