### PR TITLE
handle cubic-bezier easing

### DIFF
--- a/src/easing.js
+++ b/src/easing.js
@@ -130,6 +130,9 @@ export const configEasing = (...args) => {
       case 'spring':
         return configSpring();
       default:
+        if (easing.split("(")[0] === 'cubic-bezier') {
+            return configBezier('linear');
+        }
         warn(
           false,
           '[configEasing]: first argument should be one of \'ease\', \'ease-in\', ' +

--- a/src/easing.js
+++ b/src/easing.js
@@ -49,9 +49,14 @@ export const configBezier = (...args) => {
         [x1, y1, x2, y2] = [0.0, 0.0, 0.58, 1.0];
         break;
       default:
-        warn(false, '[configBezier]: arguments should be one of ' +
-          'oneOf \'linear\', \'ease\', \'ease-in\', \'ease-out\', ' +
-          '\'ease-in-out\', instead received %s', args);
+        var easing = args[0].split('(');
+        if (easing[0] === 'cubic-bezier' && easing[1].split(')')[0].split(',').length === 4) {
+          [x1, y1, x2, y2] = easing[1].split(')')[0].split(',').map(x => parseFloat(x));
+        } else {
+          warn(false, '[configBezier]: arguments should be one of ' +
+            'oneOf \'linear\', \'ease\', \'ease-in\', \'ease-out\', ' +
+            '\'ease-in-out\',\'cubic-bezier(x1,y1,x2,y2)\', instead received %s', args);
+        }
     }
   }
 
@@ -130,8 +135,8 @@ export const configEasing = (...args) => {
       case 'spring':
         return configSpring();
       default:
-        if (easing.split("(")[0] === 'cubic-bezier') {
-            return configBezier('linear');
+        if (easing.split('(')[0] === 'cubic-bezier') {
+          return configBezier(easing);
         }
         warn(
           false,


### PR DESCRIPTION
Temporary fix that allows css cubic-bezier function to be passed to the element through react-smooth.

For some reason it seems the result from configBezier() is not actually used, instead the initial string passed into react-smooth is used, but only certain strings can make it through, as dictated by the switch-case statements in easing.js. This small alteration adds cubic-bezier() css function to the available options without too much intrusion.

EDIT: I was wrong about the configBezier result, it seems it is used later, so passing "linear" in as a placeholder string later came back to bite me. I have now committed new code that can handle the whole 'cubic-bezier(x1,y1,x2,y2)' string being passed in all the way through to the result at the end.