### PR TITLE
Import Transition named export from react-transition-group

### DIFF
--- a/src/AnimateGroupChild.js
+++ b/src/AnimateGroupChild.js
@@ -1,5 +1,5 @@
 import React, { Component, Children } from 'react';
-import Transition from 'react-transition-group/Transition';
+import { Transition } from 'react-transition-group';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Animate from './Animate';


### PR DESCRIPTION
Lands fix for - https://github.com/recharts/react-smooth/issues/23

```
ERROR in ./node_modules/react-smooth/lib/AnimateGroupChild.js
Module not found: Error: Can't resolve 'react-transition-group/Transition' in
'\node_modules\react-smooth\lib'
@ ./node_modules/react-smooth/lib/AnimateGroupChild.js 21:18-62
@ ./node_modules/react-smooth/lib/AnimateGroup.js
@ ./node_modules/react-smooth/lib/index.js
@ ./node_modules/recharts/es6/polar/RadialBar.js
@ ./node_modules/recharts/es6/index.js
@ ./src/components/Dashboard/Main/index.js
@ ./src/components/Dashboard/index.js
@ ./src/components/App/index.js
@ ./src/index.js
@ multi (webpack)-dev-server/client?http://localhost:5000 webpack/hot/dev-server babel-polyfill react react-dom ./src/index.js
```