### PR TITLE
chore(deps): add react 17 to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "homepage": "https://github.com/recharts/react-smooth#readme",
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "lodash": "~4.17.4",


### PR DESCRIPTION
This will suppress messages similar to this:

```
warning "recharts > react-smooth@1.0.6" has incorrect peer dependency "react@^15.0.0 || ^16.0.0".
warning "recharts > react-smooth@1.0.6" has incorrect peer dependency "react-dom@^15.0.0 || ^16.0.0".
```