### PR TITLE
Allow react 17 as peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-smooth",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "homepage": "https://github.com/recharts/react-smooth#readme",
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "lodash": "~4.17.4",


### PR DESCRIPTION
Addresses #45 

React 17 has been out for 5 months with minimal breaking changes, let's allow it, shall we?

`npm demo` looks the same with either react 16 or 17 installed as a devDependency, unfortunately couldn't run tests with react 17 as enzyme doesn't support it yet. https://github.com/enzymejs/enzyme/issues/2429