### PR TITLE
Upgrade `fast-equals` to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
-        "fast-equals": "^4.0.3",
+        "fast-equals": "^5.0.0",
         "react-transition-group": "2.9.0"
       },
       "devDependencies": {
@@ -6978,9 +6978,12 @@
       "dev": true
     },
     "node_modules/fast-equals": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
-      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.0.tgz",
+      "integrity": "sha512-CjA/zqeRc1HUzFu0EIvPmcvJEQnt8+PmeeEpCKyw79ssvvGYcb70a4uSn5qb410AULdewthkKyGuz+RbjHkLfw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -19898,9 +19901,9 @@
       "dev": true
     },
     "fast-equals": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
-      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.0.tgz",
+      "integrity": "sha512-CjA/zqeRc1HUzFu0EIvPmcvJEQnt8+PmeeEpCKyw79ssvvGYcb70a4uSn5qb410AULdewthkKyGuz+RbjHkLfw=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "fast-equals": "^4.0.3",
+    "fast-equals": "^5.0.0",
     "react-transition-group": "2.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
No breaking changes for `react-smooth` really, see https://github.com/planttheidea/fast-equals/blob/master/CHANGELOG.md
