### PR TITLE
Fix/animation duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.3 / 2023-05-08
+
+### fix
+
+- treat `duration={0}` as if animation is not active by doing a check and returning early. This fixes a bug where NaN can cause a crash in the browser.
+
 ## 2.0.2 / 2023-02-23
 
 ### chore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-smooth",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-smooth",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "fast-equals": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-smooth",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "react animation library",
   "main": "lib/index",
   "module": "es6/index",

--- a/src/Animate.js
+++ b/src/Animate.js
@@ -10,12 +10,12 @@ class Animate extends PureComponent {
   constructor(props, context) {
     super(props, context);
 
-    const { isActive, attributeName, from, to, steps, children } = this.props;
+    const { isActive, attributeName, from, to, steps, children, duration } = this.props;
 
     this.handleStyleChange = this.handleStyleChange.bind(this);
     this.changeStyle = this.changeStyle.bind(this);
 
-    if (!isActive) {
+    if (!isActive || duration <= 0) {
       this.state = { style: {} };
 
       // if children is a function and animation is not active, set style to 'to'
@@ -255,7 +255,7 @@ class Animate extends PureComponent {
       return children(stateStyle);
     }
 
-    if (!isActive || count === 0) {
+    if (!isActive || count === 0 || duration <= 0) {
       return children;
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -20,7 +20,7 @@ export const getDashCase = name => name.replace(/([A-Z])/g, v => `-${v.toLowerCa
  */
 export const generatePrefixStyle = (name, value) => {
   if (IN_COMPATIBLE_PROPERTY.indexOf(name) === -1) {
-    return { [name]: value };
+    return { [name]: Number.isNaN(value) ? 0 : value };
   }
 
   const isTransition = name === 'transition';


### PR DESCRIPTION
Animation duration of `0` causes a crash in the browser when used with dashed line charts. 

This is because NaN gets computed for one of the `t` properties.

If animationDuration is less than or equal to 0 - treat it as if animation is disabled. 0 is equal to off and less than 0 doesn't make sense. 

This fixes https://github.com/recharts/recharts/issues/3565

Release new version after merge