### PR TITLE
fix: call onAnimationEnd

### DIFF
--- a/src/Animate.js
+++ b/src/Animate.js
@@ -112,6 +112,7 @@ class Animate extends PureComponent {
 
   componentWillUnmount() {
     this.mounted = false;
+    const { onAnimationEnd } = this.props;
 
     if (this.unSubscribe) {
       this.unSubscribe();
@@ -124,6 +125,10 @@ class Animate extends PureComponent {
 
     if (this.stopJSAnimation) {
       this.stopJSAnimation();
+    }
+
+    if (onAnimationEnd) {
+      onAnimationEnd();
     }
   }
 


### PR DESCRIPTION
Call onAnimationEnd on component unmount

This has been known and not fixed for a long time. 

Will need to be tested thoroughly as this _could_ but _shouldn't_ have unintended side-effects (as anything lol) 

https://github.com/recharts/react-smooth/issues/44