### PR TITLE
Remove translateStyle function and export

### DIFF
--- a/src/Animate.js
+++ b/src/Animate.js
@@ -4,7 +4,7 @@ import { deepEqual } from 'fast-equals';
 import createAnimateManager from './AnimateManager';
 import { configEasing } from './easing';
 import configUpdate from './configUpdate';
-import { getTransitionVal, identity, translateStyle } from './util';
+import { getTransitionVal, identity } from './util';
 
 class Animate extends PureComponent {
   constructor(props, context) {
@@ -254,7 +254,7 @@ class Animate extends PureComponent {
     } = this.props;
     const count = Children.count(children);
     // eslint-disable-next-line react/destructuring-assignment
-    const stateStyle = translateStyle(this.state.style);
+    const stateStyle = this.state.style;
 
     if (typeof children === 'function') {
       return children(stateStyle);

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 import Animate from './Animate';
 import { configBezier, configSpring } from './easing';
-import { translateStyle } from './util';
 import AnimateGroup from './AnimateGroup';
 
-export { configSpring, configBezier, AnimateGroup, translateStyle };
+export { configSpring, configBezier, AnimateGroup };
 
 export default Animate;

--- a/src/util.js
+++ b/src/util.js
@@ -54,19 +54,6 @@ export const mapObject = (fn, obj) =>
     {},
   );
 
-export const compose = (...args) => {
-  if (!args.length) {
-    return identity;
-  }
-
-  const fns = args.reverse();
-  // first function can receive multiply arguments
-  const firstFn = fns[0];
-  const tailsFn = fns.slice(1);
-
-  return (...composeArgs) => tailsFn.reduce((res, fn) => fn(res), firstFn(...composeArgs));
-};
-
 export const getTransitionVal = (props, duration, easing) =>
   props.map(prop => `${getDashCase(prop)} ${duration}ms ${easing}`).join(',');
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,4 @@
 /* eslint no-console: 0 */
-const PREFIX_LIST = ['Webkit', 'Moz', 'O', 'ms'];
-const IN_LINE_PREFIX_LIST = ['-webkit-', '-moz-', '-o-', '-ms-'];
-const IN_COMPATIBLE_PROPERTY = ['transform', 'transformOrigin', 'transition'];
 
 export const getIntersectionKeys = (preObj, nextObj) =>
   [Object.keys(preObj), Object.keys(nextObj)].reduce((a, b) => a.filter(c => b.includes(c)));
@@ -13,31 +10,6 @@ export const identity = param => param;
  * string => string
  */
 export const getDashCase = name => name.replace(/([A-Z])/g, v => `-${v.toLowerCase()}`);
-
-/*
- * @description: add compatible style prefix
- * (string, string) => object
- */
-export const generatePrefixStyle = (name, value) => {
-  if (IN_COMPATIBLE_PROPERTY.indexOf(name) === -1) {
-    return { [name]: Number.isNaN(value) ? 0 : value };
-  }
-
-  const isTransition = name === 'transition';
-  const camelName = name.replace(/(\w)/, v => v.toUpperCase());
-  let styleVal = value;
-
-  return PREFIX_LIST.reduce((result, property, i) => {
-    if (isTransition) {
-      styleVal = value.replace(/(transform|transform-origin)/gim, `${IN_LINE_PREFIX_LIST[i]}$1`);
-    }
-
-    return {
-      ...result,
-      [property + camelName]: styleVal,
-    };
-  }, {});
-};
 
 export const log = (...args) => {
   console.log(...args);
@@ -80,19 +52,6 @@ export const mapObject = (fn, obj) =>
       [key]: fn(key, obj[key]),
     }),
     {},
-  );
-
-/*
- * @description: add compatible prefix to style
- * object => object
- */
-export const translateStyle = style =>
-  Object.keys(style).reduce(
-    (res, key) => ({
-      ...res,
-      ...generatePrefixStyle(key, res[key]),
-    }),
-    style,
   );
 
 export const compose = (...args) => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import Animate, { translateStyle } from '../src';
+import { render } from '@testing-library/react';
+import Animate from '../src';
 
 describe('Animate', () => {
   it('Should change the style of children', (done) => {
@@ -94,21 +94,5 @@ describe('Animate', () => {
       expect(secondStatus).toEqual('yes');
       done();
     }, 1400);
-  });
-});
-
-describe('translateStyle', () => {
-  it('Should get compatible style', () => {
-    const style = {
-      transform: 'translateY(20px)',
-      transition: 'transform .4s ease',
-    };
-
-    const translatedStyle = translateStyle(style);
-
-    expect(translatedStyle.WebkitTransform).toEqual('translateY(20px)');
-    expect(translatedStyle.WebkitTransition).toEqual(
-      '-webkit-transform .4s ease',
-    );
   });
 });


### PR DESCRIPTION
This was necessary in 2017 but is not needed anymore - all browsers now support CSS transforms and transitions without prefixes.

This is a breaking change. The function export was not documented but I guess if it's exported from index then it's part of the public API. Recharts will break for example :)

https://caniuse.com/?search=transforms

Also discussed on Slack: https://recharts.slack.com/archives/C042Q5K5UDC/p1697529536898929